### PR TITLE
fix(ci): MacOSX build fails due to case insensitive APFS

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -38,7 +38,7 @@ let
       version = version;
       src = fetchArchURL nixpkgs.system archSrc;
 
-      unpackPhase = "unzip $src";
+      unpackPhase = "unzip -o $src";
 
       nativeBuildInputs = [ unzip ];
 


### PR DESCRIPTION
GitHub Action MacOS runners are using an insensitive APFS filesystem [1].

Some

Example: (from
https://github.com/numtide/nixpkgs-terraform-providers-bin/runs/5426414927?check_suite_focus=true)

```
error: builder for '/nix/store/cgr5bg7xbbfv6gprb76hiq9287bvqgnj-terraform-provider-equinix-1.5.0-alpha.1.drv' failed with exit code 1;
       last 10 log lines:
       > unpacking sources
       > Archive:  /nix/store/37w9bjkbhfng1x46bg7dacws7ksny4wf-terraform-provider-equinix_1.5.0-alpha.1_darwin_amd64.zip
       >   inflating: CHANGELOG.md
       >   inflating: LICENSE
       >   inflating: README.md
       >   inflating: equinix-migration-tool/README.md
       > replace equinix-migration-tool/readme.md? [y]es, [n]o, [A]ll, [N]one, [r]ename:  NULL
       > (EOF or read error, treating as "[N]one" ...)
       >   inflating: terraform-provider-equinix_v1.5.0-alpha.1
       >   inflating: equinix-migration-tool/equinix-migration-tool
```

[1] https://github.com/actions/virtual-environments/issues/865